### PR TITLE
Fix Long Beach SBDC link

### DIFF
--- a/db/cms_fixtures/bizport/pages/index/plan/support-options/step-content.html
+++ b/db/cms_fixtures/bizport/pages/index/plan/support-options/step-content.html
@@ -26,7 +26,7 @@
     <li>Lease Negotiation</li>
     <li>How to Use Quickbooks</li>
   </ul>
-  <a class='media-object link-box' href='www.longbeachsbdc.org/calendar' onclick="trackOutboundLink('http://longbeachsbdc.org/')" target='_blank'>
+  <a class='media-object link-box' href='http://www.longbeachsbdc.org/calendar' onclick="trackOutboundLink('http://longbeachsbdc.org/')" target='_blank'>
 <div class='media-object-section middle'>
 <div class='link-box_icon'></div>
 </div>


### PR DESCRIPTION
This link was missing it’s protocol component, so instead of linking out to http://www.longbeachsbdc.org/calendar it was expanded to http://bizport.longbeach.gov/plan/www.longbeachsbdc.org/calendar